### PR TITLE
Add some tag value parsing edge cases

### DIFF
--- a/tests/msg-split.yaml
+++ b/tests/msg-split.yaml
@@ -282,3 +282,18 @@ tests:
         - "#foo-bar"
         - "+o"
         - "foobar"
+
+  # If a tag value has a slash followed by a character which doesn't need
+  # to be escaped, the slash should be dropped.
+  - input: "@tag1=value\\1 COMMAND"
+    atoms:
+      tags:
+        tag1: "value1"
+      verb: "COMMAND"
+
+  # A slash at the end of a tag value should be dropped
+  - input: "@tag1=value1\\ COMMAND"
+    atoms:
+      tags:
+        tag1: "value1"
+      verb: "COMMAND"


### PR DESCRIPTION
It looks like the girc-go parser handles one of these differently from how we discussed, but these are the two edge cases I was missing.

```
Running split tests
Tag tag1 has wrong value. Expected value1 got value1\
 * Passed tests: 30
 * Failed tests: 1
Running join tests
 * Passed tests: 17
 * Failed tests: 0
Running mask matching tests
 * Passed tests: 3
 * Failed tests: 0
Running userhost splitting tests
 * Passed tests: 9
 * Failed tests: 0
Running hostname validation tests
 * Passed tests: 13
 * Failed tests: 0
```