### PR TITLE
README: update repository link

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,6 @@ Thanks to these sources for having open tests and/or agreeing to let me include 
 
 Some tests originate from [Mozilla's test vectors](https://dxr.mozilla.org/comm-central/source/chat/protocols/irc/test/test_ircMessage.js), which are public domain.
 
-Some tests originate from [grawity's test vectors](https://github.com/grawity/code/tree/master/lib/tests) which were WTFPL v2 licensed when they were retrieved.
+Some tests originate from [grawity's test vectors](https://github.com/grawity/irc-parse-tests) which were WTFPL v2 licensed when they were retrieved.
 
 Some tests originate from [SaberUK's test vectors](https://github.com/SaberUK/ircparser/tree/master/test) which they've indicated I'm free to include here.


### PR DESCRIPTION
The original location was broken, but I discovered the same stuff elsewhere.