### PR TITLE
Remove incorrect empty nick/ident/hostname.

### DIFF
--- a/tests/userhost-split.yaml
+++ b/tests/userhost-split.yaml
@@ -34,25 +34,10 @@ tests:
       host: "localhost"
 
   # without atoms
-  - source: "!ag@127.0.0.1"
-    atoms:
-      user: "ag"
-      host: "127.0.0.1"
-
-  - source: "coolguy!@127.0.0.1"
-    atoms:
-      nick: "coolguy"
-      host: "127.0.0.1"
-
   - source: "coolguy@127.0.0.1"
     atoms:
       nick: "coolguy"
       host: "127.0.0.1"
-
-  - source: "coolguy!ag@"
-    atoms:
-      nick: "coolguy"
-      user: "ag"
 
   - source: "coolguy!ag"
     atoms:


### PR DESCRIPTION
Per RFC 1459:

```
<prefix>   ::= <servername> | <nick> [ '!' <user> ] [ '@' <host> ]
<nick>     ::= <letter> { <letter> | <number> | <special> }
<user>     ::= <nonwhite> { <nonwhite> }
<host>     ::= see RFC 952 [DNS:4] for details on allowed hostnames
```

and per RFC 952:

```
<official hostname> ::= <hname>
<hname> ::= <name>*[.<name>]
<name>  ::= <let>[*[<let-or-digit-or-hyphen>]<let-or-digit>]
```